### PR TITLE
Add the static site linter + Cleanup documentation imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
       
       - name: Lint the static site
         uses: anishathalye/proof-html@v2
+        # Disabled
+        if: ${{ false }}
         with:
           directory: ./_site
           enforce_https: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,14 @@
 name: Continuous Integration
 
 on:
-  # We have deploy there
-  # push:
-  #  branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
   workflow_dispatch:
+    inputs:
+      runLint:
+        description: 'Run the static linter'     
+        required: false
+        default: false
 
 jobs:
   # Build job
@@ -48,8 +50,7 @@ jobs:
       
       - name: Lint the static site
         uses: anishathalye/proof-html@v2
-        # Disabled
-        if: ${{ false }}
+        if: ${{ inputs.runLint }}
         with:
           directory: ./_site
           enforce_https: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,5 @@ jobs:
           enforce_https: false
           tokens: |
             {"https://github.com": "${{ secrets.GITHUB_TOKEN }}"}
+          ignore_url: |
+             https://fonts.gstatic.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,11 @@ jobs:
               mkdocs build
             env: |
               FULL_BUILD=true
+      
+      - name: Lint the static site
+        uses: anishathalye/proof-html@v2
+        with:
+          directory: ./_site
+          enforce_https: false
+          tokens: |
+            {"https://github.com": "${{ secrets.GITHUB_TOKEN }}"}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,7 +80,7 @@ plugins:
             imports: [ README.md, CONTRIBUTING.md ]
           - name: static-analysis-plugin
             import_url: 'https://github.com/GradleUp/static-analysis-plugin?branch=master&edit_uri=/blob/master/'
-            imports: [ README.md, CHANGELOG.md ]
+            imports: [ README.md, CHANGELOG.md, LICENSE, 'docs/**' ]
           - name: shadow
             import_url: 'https://github.com/GradleUp/shadow?branch=main&edit_uri=/blob/main/'
             imports: [ README.md ]


### PR DESCRIPTION
This change adds a static linter that can be optionally triggered manually, as a GitHub action. It will be enforced once the referencing is cleaned up.

- [x] Lint the generated static site
- [ ] PARTIAL:  Import referenced content when possible
- [ ] Add redirects