### PR TITLE
Start pushing the DevContainer image when deploying site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
         with:
             imageName: gradleup/gradleup.github.io-builder
             cacheFrom: gradleup/gradleup.github.io-builder
-            push: never
+            push: always
             runCmd: |
               mkdocs build
             env: |


### PR DESCRIPTION
Leftover in #8 