### PR TITLE
Change header and URL links in the dark mode

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -29,3 +29,14 @@ h2, h3, h4 {
     color: var(--theme-main);
     font-weight: bold;
 }
+
+/* Dark Mode */
+[data-md-color-scheme="slate"] {
+    --md-hue: 210;
+    --theme-main: #f8f8f8;
+    --theme-main-lite: rgb(138, 151, 206);
+}
+
+[data-md-color-scheme="default"] {
+    --md-footer-bg-color--dark:   black;
+}


### PR DESCRIPTION
Now the dark mode is darker and more contrast w.r.t headers and links

![image](https://github.com/user-attachments/assets/eedda74f-fccf-495a-b2fa-496b8223d530)
